### PR TITLE
Implement Slice 3 lights dashboard search/filter/sort

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,6 @@ When a component grows beyond ~150 lines or contains multiple sub-components:
 2. Move shared helpers/constants into a `*.utils.ts` file.
 3. Move shared hooks into a `*.hooks.ts` file or into `lib/` if used across features.
 
-
-
 # File Size & Decomposition (Hard Rules)
 
 - Do not add new features to any file over 300 lines.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # hue-manager
 
-Slice 1 tracer bullet implemented with:
+Slice 3 tracer bullet implemented with:
 
 - React frontend shell
-- Hono backend endpoint
+- Hono backend endpoints (`/api/health`, `/api/lights`)
 - Shared Zod contract validation
 - Tailwind CSS + shadcn-style component foundation
+- Lights dashboard with search/filter/sort UX
 
 ## Run locally
 
@@ -28,9 +29,9 @@ vp run dev
 ## What this slice proves
 
 - Frontend and backend run together locally.
-- Frontend fetches `/api/health` through Vite proxy.
-- Backend response and frontend boundary both validate via the same shared Zod schema (`shared/contracts/health.ts`).
-- Overview page renders bridge/sync health card from typed backend data.
+- Frontend fetches `/api/health` and `/api/lights` through Vite proxy.
+- Backend responses and frontend boundaries both validate via shared Zod schemas (`shared/contracts/*`).
+- Overview page renders bridge/sync health and a lights dashboard with search, room/zone filters, and sort controls.
 
 ## Scripts
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -5,6 +5,11 @@ import {
   OverviewHealthResponseSchema,
   type OverviewHealthResponse,
 } from "../shared/contracts/health.ts";
+import {
+  LightsResponseSchema,
+  type Light,
+  type LightsResponse,
+} from "../shared/contracts/lights.ts";
 
 const host = process.env.API_HOST ?? "127.0.0.1";
 const port = Number(process.env.API_PORT ?? "8787");
@@ -33,8 +38,147 @@ function getOverviewHealth(): OverviewHealthResponse {
   };
 }
 
+function getMockLights(): Light[] {
+  const now = Date.now();
+
+  return [
+    {
+      id: "light-001",
+      name: "Kitchen Ceiling",
+      type: "bulb",
+      room: { id: "room-kitchen", name: "Kitchen" },
+      zone: { id: "zone-downstairs", name: "Downstairs" },
+      isOn: true,
+      brightness: 92,
+      lastUpdatedAt: new Date(now - 30_000).toISOString(),
+    },
+    {
+      id: "light-002",
+      name: "Kitchen Counter Strip",
+      type: "strip",
+      room: { id: "room-kitchen", name: "Kitchen" },
+      zone: { id: "zone-downstairs", name: "Downstairs" },
+      isOn: true,
+      brightness: 58,
+      lastUpdatedAt: new Date(now - 15_000).toISOString(),
+    },
+    {
+      id: "light-003",
+      name: "Dining Pendant",
+      type: "lamp",
+      room: { id: "room-dining", name: "Dining Room" },
+      zone: { id: "zone-downstairs", name: "Downstairs" },
+      isOn: false,
+      brightness: 0,
+      lastUpdatedAt: new Date(now - 180_000).toISOString(),
+    },
+    {
+      id: "light-004",
+      name: "Living Main",
+      type: "bulb",
+      room: { id: "room-living", name: "Living Room" },
+      zone: { id: "zone-downstairs", name: "Downstairs" },
+      isOn: true,
+      brightness: 74,
+      lastUpdatedAt: new Date(now - 60_000).toISOString(),
+    },
+    {
+      id: "light-005",
+      name: "Living Floor Lamp",
+      type: "lamp",
+      room: { id: "room-living", name: "Living Room" },
+      zone: { id: "zone-downstairs", name: "Downstairs" },
+      isOn: true,
+      brightness: 41,
+      lastUpdatedAt: new Date(now - 45_000).toISOString(),
+    },
+    {
+      id: "light-006",
+      name: "Hallway North",
+      type: "bulb",
+      room: { id: "room-hallway", name: "Hallway" },
+      zone: { id: "zone-downstairs", name: "Downstairs" },
+      isOn: false,
+      brightness: 0,
+      lastUpdatedAt: new Date(now - 420_000).toISOString(),
+    },
+    {
+      id: "light-007",
+      name: "Primary Bedroom Main",
+      type: "bulb",
+      room: { id: "room-primary-bedroom", name: "Primary Bedroom" },
+      zone: { id: "zone-upstairs", name: "Upstairs" },
+      isOn: true,
+      brightness: 68,
+      lastUpdatedAt: new Date(now - 22_000).toISOString(),
+    },
+    {
+      id: "light-008",
+      name: "Primary Bedside Left",
+      type: "lamp",
+      room: { id: "room-primary-bedroom", name: "Primary Bedroom" },
+      zone: { id: "zone-upstairs", name: "Upstairs" },
+      isOn: false,
+      brightness: 0,
+      lastUpdatedAt: new Date(now - 900_000).toISOString(),
+    },
+    {
+      id: "light-009",
+      name: "Guest Bedroom",
+      type: "bulb",
+      room: { id: "room-guest-bedroom", name: "Guest Bedroom" },
+      zone: { id: "zone-upstairs", name: "Upstairs" },
+      isOn: false,
+      brightness: 0,
+      lastUpdatedAt: new Date(now - 1_200_000).toISOString(),
+    },
+    {
+      id: "light-010",
+      name: "Office Desk Lamp",
+      type: "lamp",
+      room: { id: "room-office", name: "Office" },
+      zone: { id: "zone-upstairs", name: "Upstairs" },
+      isOn: true,
+      brightness: 83,
+      lastUpdatedAt: new Date(now - 12_000).toISOString(),
+    },
+    {
+      id: "light-011",
+      name: "Office Ambient Strip",
+      type: "strip",
+      room: { id: "room-office", name: "Office" },
+      zone: { id: "zone-upstairs", name: "Upstairs" },
+      isOn: true,
+      brightness: 39,
+      lastUpdatedAt: new Date(now - 9_000).toISOString(),
+    },
+    {
+      id: "light-012",
+      name: "Garage Plug Lamp",
+      type: "plug",
+      room: { id: "room-garage", name: "Garage" },
+      zone: null,
+      isOn: false,
+      brightness: 0,
+      lastUpdatedAt: new Date(now - 2_700_000).toISOString(),
+    },
+  ];
+}
+
+function getLightsResponse(): LightsResponse {
+  return {
+    generatedAt: new Date().toISOString(),
+    lights: getMockLights(),
+  };
+}
+
 app.get("/api/health", (context) => {
   const payload = OverviewHealthResponseSchema.parse(getOverviewHealth());
+  return context.json(payload);
+});
+
+app.get("/api/lights", (context) => {
+  const payload = LightsResponseSchema.parse(getLightsResponse());
   return context.json(payload);
 });
 

--- a/shared/contracts/lights.ts
+++ b/shared/contracts/lights.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+export const LightTypeSchema = z.enum(["bulb", "strip", "lamp", "plug"]);
+
+export const LightGroupSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+});
+
+export const LightSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  type: LightTypeSchema,
+  room: LightGroupSchema,
+  zone: LightGroupSchema.nullable(),
+  isOn: z.boolean(),
+  brightness: z.number().int().min(0).max(100),
+  lastUpdatedAt: z.string().datetime(),
+});
+
+export const LightsResponseSchema = z.object({
+  generatedAt: z.string().datetime(),
+  lights: z.array(LightSchema),
+});
+
+export type LightType = z.infer<typeof LightTypeSchema>;
+export type LightGroup = z.infer<typeof LightGroupSchema>;
+export type Light = z.infer<typeof LightSchema>;
+export type LightsResponse = z.infer<typeof LightsResponseSchema>;
+
+export function parseLightsResponse(data: unknown): LightsResponse {
+  return LightsResponseSchema.parse(data);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { OverviewHealthCard } from "./components/OverviewHealthCard/OverviewHealthCard";
+import { LightsDashboard } from "./components/LightsDashboard/LightsDashboard";
 
 export function App() {
   return (
@@ -13,6 +14,7 @@ export function App() {
       </header>
 
       <OverviewHealthCard />
+      <LightsDashboard />
     </main>
   );
 }

--- a/src/components/LightsDashboard/LightsDashboard.hooks.ts
+++ b/src/components/LightsDashboard/LightsDashboard.hooks.ts
@@ -1,0 +1,60 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { parseLightsResponse } from "../../../shared/contracts/lights";
+import { type LightFilters, type LightsDashboardData } from "./LightsDashboard.types";
+import {
+  buildRoomOptions,
+  buildZoneOptions,
+  filterAndSortLights,
+  getInitialLightFilters,
+} from "./LightsDashboard.utils";
+
+const LIGHTS_QUERY_KEY = ["lights-dashboard"] as const;
+
+async function requestLights() {
+  const response = await fetch("/api/lights");
+  if (!response.ok) {
+    throw new Error(`Lights endpoint failed (${response.status})`);
+  }
+
+  const payload = await response.json();
+  return parseLightsResponse(payload);
+}
+
+export function useLightsDashboard() {
+  const [filters, setFilters] = useState<LightFilters>(getInitialLightFilters);
+  const query = useQuery({
+    queryKey: LIGHTS_QUERY_KEY,
+    queryFn: requestLights,
+    staleTime: 10_000,
+  });
+
+  const data: LightsDashboardData = useMemo(() => {
+    const lights = query.data?.lights ?? [];
+    const filteredLights = filterAndSortLights(lights, filters);
+
+    return {
+      lights,
+      filteredLights,
+      roomOptions: buildRoomOptions(lights),
+      zoneOptions: buildZoneOptions(lights),
+    };
+  }, [filters, query.data?.lights]);
+
+  function updateFilters(nextPartial: Partial<LightFilters>) {
+    setFilters((current) => ({
+      ...current,
+      ...nextPartial,
+    }));
+  }
+
+  return {
+    ...data,
+    filters,
+    isLoading: query.isLoading,
+    isRefreshing: query.isFetching,
+    error: query.error,
+    refresh: query.refetch,
+    updateFilters,
+  };
+}

--- a/src/components/LightsDashboard/LightsDashboard.tsx
+++ b/src/components/LightsDashboard/LightsDashboard.tsx
@@ -1,0 +1,73 @@
+import { Card } from "../ui/Card/Card";
+import { CardContent } from "../ui/Card/CardContent";
+import { CardHeader } from "../ui/Card/CardHeader";
+import { CardTitle } from "../ui/Card/CardTitle";
+import { LightsDashboardFilters } from "./LightsDashboardFilters";
+import { useLightsDashboard } from "./LightsDashboard.hooks";
+import { LightsDashboardList } from "./LightsDashboardList";
+import { UNASSIGNED_ZONE_FILTER } from "./LightsDashboard.types";
+
+export function LightsDashboard() {
+  const {
+    error,
+    filters,
+    filteredLights,
+    isLoading,
+    isRefreshing,
+    lights,
+    refresh,
+    roomOptions,
+    updateFilters,
+    zoneOptions,
+  } = useLightsDashboard();
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <CardTitle>Lights</CardTitle>
+          <button
+            className="rounded-md border border-border px-3 py-1 text-xs font-medium text-slate-100 transition hover:border-slate-500 disabled:cursor-not-allowed disabled:opacity-60"
+            type="button"
+            onClick={() => {
+              void refresh();
+            }}
+            disabled={isRefreshing}
+          >
+            {isRefreshing ? "Refreshing..." : "Refresh"}
+          </button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <LightsDashboardFilters
+          filters={filters}
+          roomOptions={roomOptions}
+          zoneOptions={zoneOptions}
+          onUpdateFilters={updateFilters}
+        />
+
+        {error ? (
+          <p className="rounded-md border border-red-500/40 bg-red-950/20 px-3 py-2 text-sm text-red-200">
+            Unable to load lights: {error.message}
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <p>
+            Showing {filteredLights.length} of {lights.length} lights
+          </p>
+          {filters.zoneId === UNASSIGNED_ZONE_FILTER ? <p>Filtered to unassigned zone</p> : null}
+        </div>
+
+        {isLoading ? (
+          <p className="text-sm text-slate-300">Loading lights...</p>
+        ) : filteredLights.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No lights matched your filters.</p>
+        ) : (
+          <LightsDashboardList lights={filteredLights} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/LightsDashboard/LightsDashboard.types.ts
+++ b/src/components/LightsDashboard/LightsDashboard.types.ts
@@ -1,0 +1,30 @@
+import type { Light } from "../../../shared/contracts/lights";
+
+export const UNASSIGNED_ZONE_FILTER = "__unassigned__";
+
+export type LightSortOption =
+  | "name-asc"
+  | "name-desc"
+  | "brightness-desc"
+  | "brightness-asc"
+  | "updated-desc"
+  | "updated-asc";
+
+export type LightFilters = {
+  searchQuery: string;
+  roomId: string;
+  zoneId: string;
+  sort: LightSortOption;
+};
+
+export type LightFilterOption = {
+  value: string;
+  label: string;
+};
+
+export type LightsDashboardData = {
+  lights: Light[];
+  filteredLights: Light[];
+  roomOptions: LightFilterOption[];
+  zoneOptions: LightFilterOption[];
+};

--- a/src/components/LightsDashboard/LightsDashboard.utils.test.ts
+++ b/src/components/LightsDashboard/LightsDashboard.utils.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "vite-plus/test";
+import type { Light } from "../../../shared/contracts/lights";
+import {
+  buildRoomOptions,
+  buildZoneOptions,
+  filterAndSortLights,
+  formatLightUpdatedAt,
+  getInitialLightFilters,
+  matchesSearchQuery,
+} from "./LightsDashboard.utils";
+import { UNASSIGNED_ZONE_FILTER } from "./LightsDashboard.types";
+
+const LIGHT_FIXTURES: Light[] = [
+  {
+    id: "a1",
+    name: "Kitchen Ceiling",
+    type: "bulb",
+    room: { id: "room-kitchen", name: "Kitchen" },
+    zone: { id: "zone-downstairs", name: "Downstairs" },
+    isOn: true,
+    brightness: 90,
+    lastUpdatedAt: "2026-03-28T10:00:00.000Z",
+  },
+  {
+    id: "b2",
+    name: "Office Lamp",
+    type: "lamp",
+    room: { id: "room-office", name: "Office" },
+    zone: null,
+    isOn: false,
+    brightness: 0,
+    lastUpdatedAt: "2026-03-28T09:00:00.000Z",
+  },
+  {
+    id: "c3",
+    name: "Dining Strip",
+    type: "strip",
+    room: { id: "room-dining", name: "Dining Room" },
+    zone: { id: "zone-downstairs", name: "Downstairs" },
+    isOn: true,
+    brightness: 45,
+    lastUpdatedAt: "2026-03-28T11:00:00.000Z",
+  },
+];
+
+describe("LightsDashboard.utils", () => {
+  test("builds unique room options sorted by label", () => {
+    expect(buildRoomOptions(LIGHT_FIXTURES)).toEqual([
+      { value: "room-dining", label: "Dining Room" },
+      { value: "room-kitchen", label: "Kitchen" },
+      { value: "room-office", label: "Office" },
+    ]);
+  });
+
+  test("builds unique zone options and includes unassigned entry", () => {
+    expect(buildZoneOptions(LIGHT_FIXTURES)).toEqual([
+      { value: "zone-downstairs", label: "Downstairs" },
+      { value: UNASSIGNED_ZONE_FILTER, label: "Unassigned zone" },
+    ]);
+  });
+
+  test("matches search query against id/name/type/room/zone", () => {
+    expect(matchesSearchQuery(LIGHT_FIXTURES[0], "kitchen")).toBe(true);
+    expect(matchesSearchQuery(LIGHT_FIXTURES[0], "downstairs")).toBe(true);
+    expect(matchesSearchQuery(LIGHT_FIXTURES[1], "lamp")).toBe(true);
+    expect(matchesSearchQuery(LIGHT_FIXTURES[2], "garage")).toBe(false);
+  });
+
+  test("filters by room and zone", () => {
+    const filtered = filterAndSortLights(LIGHT_FIXTURES, {
+      ...getInitialLightFilters(),
+      roomId: "room-kitchen",
+      zoneId: "zone-downstairs",
+    });
+
+    expect(filtered.map((light) => light.id)).toEqual(["a1"]);
+  });
+
+  test("filters by unassigned zone option", () => {
+    const filtered = filterAndSortLights(LIGHT_FIXTURES, {
+      ...getInitialLightFilters(),
+      zoneId: UNASSIGNED_ZONE_FILTER,
+    });
+
+    expect(filtered.map((light) => light.id)).toEqual(["b2"]);
+  });
+
+  test("sorts by selected sort option", () => {
+    const byBrightness = filterAndSortLights(LIGHT_FIXTURES, {
+      ...getInitialLightFilters(),
+      sort: "brightness-desc",
+    });
+    expect(byBrightness.map((light) => light.id)).toEqual(["a1", "c3", "b2"]);
+
+    const byUpdated = filterAndSortLights(LIGHT_FIXTURES, {
+      ...getInitialLightFilters(),
+      sort: "updated-desc",
+    });
+    expect(byUpdated.map((light) => light.id)).toEqual(["c3", "a1", "b2"]);
+  });
+
+  test("formats timestamp for UI display", () => {
+    expect(formatLightUpdatedAt("2026-03-28T10:00:00.000Z")).not.toHaveLength(0);
+  });
+});

--- a/src/components/LightsDashboard/LightsDashboard.utils.ts
+++ b/src/components/LightsDashboard/LightsDashboard.utils.ts
@@ -1,0 +1,129 @@
+import type { Light } from "../../../shared/contracts/lights";
+import {
+  type LightFilterOption,
+  type LightFilters,
+  type LightSortOption,
+  UNASSIGNED_ZONE_FILTER,
+} from "./LightsDashboard.types";
+
+export const LIGHT_SORT_OPTIONS: Array<{ value: LightSortOption; label: string }> = [
+  { value: "name-asc", label: "Name (A-Z)" },
+  { value: "name-desc", label: "Name (Z-A)" },
+  { value: "brightness-desc", label: "Brightness (high-low)" },
+  { value: "brightness-asc", label: "Brightness (low-high)" },
+  { value: "updated-desc", label: "Recently updated" },
+  { value: "updated-asc", label: "Least recently updated" },
+];
+
+export function getInitialLightFilters(): LightFilters {
+  return {
+    searchQuery: "",
+    roomId: "",
+    zoneId: "",
+    sort: "name-asc",
+  };
+}
+
+export function buildRoomOptions(lights: Light[]): LightFilterOption[] {
+  const uniqueRooms = new Map<string, string>();
+
+  lights.forEach((light) => {
+    uniqueRooms.set(light.room.id, light.room.name);
+  });
+
+  return [...uniqueRooms.entries()]
+    .sort((left, right) => left[1].localeCompare(right[1]))
+    .map(([value, label]) => ({ value, label }));
+}
+
+export function buildZoneOptions(lights: Light[]): LightFilterOption[] {
+  const uniqueZones = new Map<string, string>();
+  let includesUnassigned = false;
+
+  lights.forEach((light) => {
+    if (light.zone === null) {
+      includesUnassigned = true;
+      return;
+    }
+
+    uniqueZones.set(light.zone.id, light.zone.name);
+  });
+
+  const options = [...uniqueZones.entries()]
+    .sort((left, right) => left[1].localeCompare(right[1]))
+    .map(([value, label]) => ({ value, label }));
+
+  if (includesUnassigned) {
+    options.push({
+      value: UNASSIGNED_ZONE_FILTER,
+      label: "Unassigned zone",
+    });
+  }
+
+  return options;
+}
+
+function compareBySort(left: Light, right: Light, sort: LightSortOption): number {
+  switch (sort) {
+    case "name-desc":
+      return right.name.localeCompare(left.name);
+    case "brightness-desc":
+      return right.brightness - left.brightness;
+    case "brightness-asc":
+      return left.brightness - right.brightness;
+    case "updated-desc":
+      return new Date(right.lastUpdatedAt).getTime() - new Date(left.lastUpdatedAt).getTime();
+    case "updated-asc":
+      return new Date(left.lastUpdatedAt).getTime() - new Date(right.lastUpdatedAt).getTime();
+    case "name-asc":
+    default:
+      return left.name.localeCompare(right.name);
+  }
+}
+
+export function matchesSearchQuery(light: Light, searchQuery: string): boolean {
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  const searchableSegments = [
+    light.id,
+    light.name,
+    light.type,
+    light.room.name,
+    light.zone?.name ?? "",
+  ].map((segment) => segment.toLowerCase());
+
+  return searchableSegments.some((segment) => segment.includes(normalizedQuery));
+}
+
+export function filterAndSortLights(lights: Light[], filters: LightFilters): Light[] {
+  return lights
+    .filter((light) => {
+      if (!matchesSearchQuery(light, filters.searchQuery)) {
+        return false;
+      }
+
+      if (filters.roomId && light.room.id !== filters.roomId) {
+        return false;
+      }
+
+      if (filters.zoneId) {
+        if (filters.zoneId === UNASSIGNED_ZONE_FILTER) {
+          if (light.zone !== null) {
+            return false;
+          }
+        } else if (light.zone?.id !== filters.zoneId) {
+          return false;
+        }
+      }
+
+      return true;
+    })
+    .sort((left, right) => compareBySort(left, right, filters.sort));
+}
+
+export function formatLightUpdatedAt(dateIsoString: string): string {
+  return new Date(dateIsoString).toLocaleTimeString();
+}

--- a/src/components/LightsDashboard/LightsDashboardFilters.tsx
+++ b/src/components/LightsDashboard/LightsDashboardFilters.tsx
@@ -1,0 +1,86 @@
+import type { LightFilterOption, LightFilters } from "./LightsDashboard.types";
+import { LIGHT_SORT_OPTIONS } from "./LightsDashboard.utils";
+
+type LightsDashboardFiltersProps = {
+  filters: LightFilters;
+  roomOptions: LightFilterOption[];
+  zoneOptions: LightFilterOption[];
+  onUpdateFilters: (nextPartial: Partial<LightFilters>) => void;
+};
+
+export function LightsDashboardFilters({
+  filters,
+  roomOptions,
+  zoneOptions,
+  onUpdateFilters,
+}: LightsDashboardFiltersProps) {
+  return (
+    <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+      <label className="space-y-1 text-sm text-muted-foreground">
+        <span>Search</span>
+        <input
+          type="search"
+          value={filters.searchQuery}
+          onChange={(event) => {
+            onUpdateFilters({ searchQuery: event.target.value });
+          }}
+          placeholder="Name, id, type, room, zone"
+          className="w-full rounded-md border border-border bg-slate-900/70 px-3 py-2 text-sm text-slate-100 outline-none transition focus-visible:border-slate-500"
+        />
+      </label>
+
+      <label className="space-y-1 text-sm text-muted-foreground">
+        <span>Room</span>
+        <select
+          value={filters.roomId}
+          onChange={(event) => {
+            onUpdateFilters({ roomId: event.target.value });
+          }}
+          className="w-full rounded-md border border-border bg-slate-900/70 px-3 py-2 text-sm text-slate-100 outline-none transition focus-visible:border-slate-500"
+        >
+          <option value="">All rooms</option>
+          {roomOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="space-y-1 text-sm text-muted-foreground">
+        <span>Zone</span>
+        <select
+          value={filters.zoneId}
+          onChange={(event) => {
+            onUpdateFilters({ zoneId: event.target.value });
+          }}
+          className="w-full rounded-md border border-border bg-slate-900/70 px-3 py-2 text-sm text-slate-100 outline-none transition focus-visible:border-slate-500"
+        >
+          <option value="">All zones</option>
+          {zoneOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="space-y-1 text-sm text-muted-foreground">
+        <span>Sort</span>
+        <select
+          value={filters.sort}
+          onChange={(event) => {
+            onUpdateFilters({ sort: event.target.value as typeof filters.sort });
+          }}
+          className="w-full rounded-md border border-border bg-slate-900/70 px-3 py-2 text-sm text-slate-100 outline-none transition focus-visible:border-slate-500"
+        >
+          {LIGHT_SORT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/src/components/LightsDashboard/LightsDashboardList.tsx
+++ b/src/components/LightsDashboard/LightsDashboardList.tsx
@@ -1,0 +1,42 @@
+import { Badge } from "../ui/Badge/Badge";
+import type { Light } from "../../../shared/contracts/lights";
+import { formatLightUpdatedAt } from "./LightsDashboard.utils";
+
+type LightsDashboardListProps = {
+  lights: Light[];
+};
+
+export function LightsDashboardList({ lights }: LightsDashboardListProps) {
+  return (
+    <div className="space-y-2">
+      {lights.map((light) => (
+        <div
+          key={light.id}
+          className="grid gap-2 rounded-md border border-border bg-slate-900/50 p-3 sm:grid-cols-[2fr_1fr_1fr_auto]"
+        >
+          <div>
+            <p className="text-sm font-medium text-slate-100">{light.name}</p>
+            <p className="text-xs text-muted-foreground">{light.id}</p>
+          </div>
+
+          <div className="text-xs text-muted-foreground">
+            <p>{light.room.name}</p>
+            <p>{light.zone?.name ?? "Unassigned zone"}</p>
+          </div>
+
+          <div className="text-xs text-muted-foreground">
+            <p>Type: {light.type}</p>
+            <p>Brightness: {light.brightness}%</p>
+          </div>
+
+          <div className="justify-self-start sm:justify-self-end">
+            <Badge variant={light.isOn ? "ok" : "down"}>{light.isOn ? "On" : "Off"}</Badge>
+            <p className="mt-1 text-right text-xs text-muted-foreground">
+              Updated {formatLightUpdatedAt(light.lastUpdatedAt)}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/contracts/lights.contract.test.ts
+++ b/src/contracts/lights.contract.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vite-plus/test";
+import { parseLightsResponse } from "../../shared/contracts/lights";
+
+describe("lights contract", () => {
+  test("parses a valid lights response", () => {
+    const parsed = parseLightsResponse({
+      generatedAt: "2026-03-28T12:00:00.000Z",
+      lights: [
+        {
+          id: "light-001",
+          name: "Kitchen Ceiling",
+          type: "bulb",
+          room: { id: "room-kitchen", name: "Kitchen" },
+          zone: { id: "zone-downstairs", name: "Downstairs" },
+          isOn: true,
+          brightness: 84,
+          lastUpdatedAt: "2026-03-28T11:59:00.000Z",
+        },
+      ],
+    });
+
+    expect(parsed.lights).toHaveLength(1);
+    expect(parsed.lights[0].room.name).toBe("Kitchen");
+  });
+
+  test("rejects invalid brightness values", () => {
+    expect(() =>
+      parseLightsResponse({
+        generatedAt: "2026-03-28T12:00:00.000Z",
+        lights: [
+          {
+            id: "light-001",
+            name: "Kitchen Ceiling",
+            type: "bulb",
+            room: { id: "room-kitchen", name: "Kitchen" },
+            zone: null,
+            isOn: true,
+            brightness: 101,
+            lastUpdatedAt: "2026-03-28T11:59:00.000Z",
+          },
+        ],
+      }),
+    ).toThrowError();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement Slice 3 (`#4`) by adding a typed lights contract and backend `/api/lights` endpoint
- add a new Lights dashboard UI with:
  - list rendering from backend data
  - search across id/name/type/room/zone
  - room and zone filters (including unassigned zone)
  - operator-focused sort options (name, brightness, updated)
- add focused tests for lights contracts and filtering/sorting utilities
- update README to reflect current slice capabilities

## Parent PRD
- #1

## Verification
- `npx vp check`
- `npx vp test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f05acdb-1705-4bff-b252-2067658c62ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f05acdb-1705-4bff-b252-2067658c62ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

